### PR TITLE
Fix bug with win script

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -27,8 +27,9 @@ function addToken(event){
 }
 
 function processMove(event) {
-  if (addToken(event)){
+  if (addToken(event)) {
     if (game.checkForWin()) {
+      gameBoard.removeEventListener('click', processMove)
       game.activePlayer.recordWin()
       updateGameBoard()
       updateTurnDisplay(' WINS!')
@@ -61,4 +62,5 @@ function resetAfterWin() {
   updateGameBoard()
   game.passTurn()
   updateTurnDisplay('\'s TURN')
+  gameBoard.addEventListener('click', processMove)
 }


### PR DESCRIPTION
Added a script to remove the `gameBoard` event listener on a win, and add it back in when we finish resetting the board. This fixes a bug where you could place tokens while the win script was running and influence the turn order for the next game.